### PR TITLE
Change method remove

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -856,7 +856,7 @@ class Bree extends EventEmitter {
     const job = this.config.jobs.find((j) => j.name === name);
     if (!job) throw new Error(`Job "${name}" does not exist`);
 
-    this.config.jobs = this.config.jobs.find((j) => j.name !== name);
+    this.config.jobs = this.config.jobs.filter((j) => j.name !== name);
 
     // make sure it also closes any open workers
     this.stop(name);


### PR DESCRIPTION
In the line number 859 you should use filter instead of find method because only you get the first job that achieve the condition. This break the stop method.
Regards,
Juanlu.